### PR TITLE
Potato hvac/add linkedlist method to list

### DIFF
--- a/models/linkedList.py
+++ b/models/linkedList.py
@@ -28,3 +28,11 @@ class ListNode:
         for value in values[1:]:
             head.add(value)
         return head
+
+    def to_list(self) -> list:
+        values = list()
+        head = self
+        while head:
+            values.append(head.val)
+            head = head.next
+        return values

--- a/models/linkedList_test.py
+++ b/models/linkedList_test.py
@@ -2,38 +2,30 @@ import unittest
 from linkedList import ListNode
 
 
-def get_linked_list_values(head: ListNode) -> list:
-    values = list()
-    while head:
-        values.append(head.val)
-        head = head.next
-    return values
-
-
 class TestLinkedList(unittest.TestCase):
 
     def test_123(self):
         input = [1, 2, 3]
         linked_list = ListNode.build(input)
-        output = get_linked_list_values(linked_list)
+        output = linked_list.to_list()
         self.assertEqual(input, output)
 
     def test_minus8634(self):
         input = [-8, -9, -3, -4]
         linked_list = ListNode.build(input)
-        output = get_linked_list_values(linked_list)
+        output = linked_list.to_list()
         self.assertEqual(input, output)
 
     def test_string(self):
         input = ['this', 'is', 'a', 'string', 'test']
         linked_list = ListNode.build(input)
-        output = get_linked_list_values(linked_list)
+        output = linked_list.to_list()
         self.assertEqual(input, output)
 
     def test_large(self):
         input = [2**30, -30**5, 8**16, 100*1000000]
         linked_list = ListNode.build(input)
-        output = get_linked_list_values(linked_list)
+        output = linked_list.to_list()
         self.assertEqual(input, output)
 
 


### PR DESCRIPTION
I like your helper method in the unit test but it's really taking an object and converting it into a different object type. This is the perfect kind of thing to include in that objects methods. 

to_type is a common method name for object to object 
eg: to_s (to_string), to_int, to_json